### PR TITLE
Upgrade jest

### DIFF
--- a/4_9_react_native/NewProject/package.json
+++ b/4_9_react_native/NewProject/package.json
@@ -12,10 +12,10 @@
     "react-native": "0.54.2"
   },
   "devDependencies": {
-    "babel-jest": "23.0.0-alpha.0",
+    "babel-jest": "23.0.0",
     "babel-preset-react-native": "4.0.0",
     "flow-bin": "^0.65.0",
-    "jest": "23.0.0-alpha.0",
+    "jest": "23.0.0",
     "react-test-renderer": "16.3.0-alpha.2"
   },
   "jest": {

--- a/4_9_react_native/ReactNativeChat/package.json
+++ b/4_9_react_native/ReactNativeChat/package.json
@@ -12,10 +12,10 @@
     "react-navigation": "^1.5.7"
   },
   "devDependencies": {
-    "babel-jest": "23.0.0-alpha.0",
+    "babel-jest": "23.0.0",
     "babel-preset-react-native": "4.0.0",
     "flow-bin": "^0.65.0",
-    "jest": "23.0.0-alpha.0",
+    "jest": "23.0.0",
     "react-test-renderer": "16.3.0-alpha.2"
   },
   "jest": {


### PR DESCRIPTION
https://github.com/okachijs/jsframeworkbook/pull/20#issuecomment-415431472

ライブラリのバージョンはあげない方針と聞いていますが、
alpha から正式リリースへの切り替えについては一度ご検討頂ければと思いました。

```
npm ERR! code E404
npm ERR! 404 Not Found: jest@https://registry.npmjs.org/jest/-/jest-23.0.0-alpha.0.tgz
```

fixes #22