### PR TITLE
fix typo 'chanel' to 'channel'.

### DIFF
--- a/3_8_vue_js/src/components/Chat/chat.css
+++ b/3_8_vue_js/src/components/Chat/chat.css
@@ -46,7 +46,7 @@ ul {
 /*grid-template-rows: auto 1fr auto;*/
 /*}*/
 
-/*.chanel {*/
+/*.channel {*/
 /*grid-row: 1 / span 3;*/
 /*grid-column: 1 / 2;*/
 /*}*/

--- a/3_8_vue_js/src/components/Chat/chat.pug
+++ b/3_8_vue_js/src/components/Chat/chat.pug
@@ -12,7 +12,7 @@ el-container
       el-button("@click"="send_message") SEND
 
 //.view
-//  .chanel
+//  .channel
 //    ul
 //      li(v-for="(channel) in channels")
 //        router-link(:to="{name: 'channel', params: { cname: channel }}") {{ channel }}


### PR DESCRIPTION
3_8_vue_jsのコードにtypoと思われる箇所があったので修正しました。
[補足]書籍p.147(初版第1刷)に当該コードが例として記載。
